### PR TITLE
Split the project into QtNdi library and QtNdiMonitoCapture app

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,21 +4,21 @@
 # https://github.com/obsproject/obs-studio/blob/master/.github/workflows/main.yml
 #
 
-name: 'CI'
+name: CI
 
 on:
   push:
     paths-ignore:
       - '**.md'
     branches:
-      - "main"
+      - main
     tags:
       - '*'
   pull_request:
     paths-ignore:
       - '**.md'
     branches:
-      - "main"
+      - main
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -30,24 +30,26 @@ jobs:
   # https://github.com/obsproject/obs-studio/blob/master/.github/workflows/main.yml#L282 +/- a few lines
   #
   windows_build:
-    name: 'Windows'
+    name: Windows
     runs-on: [windows-2022]
     if: always()
     steps:
-      - name: 'Checkout'
+      - name: Checkout
         uses: actions/checkout@v3
 
-      - name: 'Install Qt6'
-        uses: jurplel/install-qt-action@v3
+      - name: Install Qt6
+        uses: jurplel/install-qt-action@v4
         with:
           version: 6.9.1
+          host: windows
+          target: desktop
           arch: win64_msvc2022_64
-          modules: 'qtmultimedia'
-          tools: 'tools_ifw'
+          modules: qtmultimedia
+          tools: tools_ifw
           setup-python: false
 
-      - name: 'Install Qt JOM'
-        working-directory: ${{ env.Qt6_DIR }}
+      - name: Install Qt JOM
+        working-directory: ${{ env.QT_ROOT_DIR }}
         shell: cmd
         run: |
           mkdir ..\..\Tools\QtCreator\bin\
@@ -57,19 +59,19 @@ jobs:
           del jom.zip
           popd
 
-      - name: 'Build & Package'
+      - name: Build & Package
         id: buildAndPackage
         shell: pwsh
         run: |
-          & CI\windows-build.ps1 "CONFIG+=package"
+          CI\windows-build.ps1 "CONFIG+=package"
 
-      - name: 'Upload Artifact'
+      - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: 'QtNdiMonitorCaptureInstaller'
+          name: QtNdiMonitorCaptureInstaller
           path: ${{ github.workspace }}/app/installer/QtNdiMonitorCaptureInstaller.exe
 
-      - name: 'Upload Release'
+      - name: Upload Release
         if: ${{ startsWith(github.ref, 'refs/tags/') && github.event_name != 'pull_request' }}
         uses: svenstaro/upload-release-action@v2
         with:

--- a/QtNdiProject.pro
+++ b/QtNdiProject.pro
@@ -1,0 +1,8 @@
+TEMPLATE = subdirs
+
+SUBDIRS += QtNdi QtNdiMonitorCapture
+
+QtNdi.file = lib/QtNdi.pro
+
+QtNdiMonitorCapture.file = app/QtNdiMonitorCapture.pro
+QtNdiMonitorCapture.depends = QtNdi

--- a/README.md
+++ b/README.md
@@ -72,20 +72,22 @@ Requirements:
 * Qt6 6.9.1 installed with the following components:
   * MSVC 2022 64-bit
   * Qt Multimedia
-  * Qt Creator 9.0.2
-  * Qt Installer Framework 4.5
-* NDI Advanced SDK to be installed.  
-  I could have just required the non-Advanced SDK, but I hope to one day add KVM support, which requires the Advanced SDK.
+  * Qt Creator 17.0.0
+  * Qt Installer Framework 4.10.0
+* NDI [Advanced] SDK installed.  
+  I could have just required the non-Advanced SDK,
+  but I hope to one day add KVM support,
+  which requires the Advanced SDK.
 
 ### Steps:
 
-#### Qt Creator 9.0.2 IDE
+#### Qt Creator 17.0.0 IDE
 1. Launch Qt Creator
-2. Open the QtNdiMonitorCapture.pro file
+2. Open the QtNdiProject.pro file
 3. Build and Run
 
-#### PowerShell 7.3.3 Command-Line
-1. `$env:Qt6_DIR = 'C:\Qt\6.4.2\msvc2019_64\'`
+#### PowerShell 7.5.2 Command-Line
+1. `$env:QT_ROOT_DIR = 'C:\Qt\6.9.1\msvc2022_64\'`
 2. `CI\windows-build.ps1 "CONFIG+=package"`
 
 ## TODO

--- a/app/QtNdiMonitorCapture.pro
+++ b/app/QtNdiMonitorCapture.pro
@@ -9,22 +9,19 @@ CONFIG += c++17
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
 INCLUDEPATH += ../lib/
-INCLUDEPATH += ../lib/GraphicsCapture/
+
+win32:CONFIG(release, debug|release): LIBS += -L$$OUT_PWD/../lib/release/ -lQtNdi
+else:win32:CONFIG(debug, debug|release): LIBS += -L$$OUT_PWD/../lib/debug/ -lQtNdi
+else:unix: LIBS += -L$$OUT_PWD/../lib/ -lQtNdi
+
+DEPENDPATH += $$PWD/../lib
 
 HEADERS += \
-    MainWindow.h \
-    ../lib/ndireceiver.h \
-    ../lib/ndireceiverworker.h \
-    ../lib/ndisender.h \
-    ../lib/ndiwrapper.h
+    MainWindow.h
 
 SOURCES += \
     main.cpp \
     MainWindow.cpp \
-    ../lib/ndireceiver.cpp \
-    ../lib/ndireceiverworker.cpp \
-    ../lib/ndisender.cpp \
-    ../lib/ndiwrapper.cpp
 
 RESOURCES = resources.qrc
 

--- a/lib/QtNdi.pro
+++ b/lib/QtNdi.pro
@@ -1,0 +1,31 @@
+QT -= gui
+QT += multimedia
+
+TEMPLATE = lib
+CONFIG += staticlib
+
+CONFIG += c++17
+
+HEADERS += \
+    qtndi.h \
+    ndireceiver.h \
+    ndireceiverworker.h \
+    ndisender.h \
+    ndiwrapper.h
+
+SOURCES += \
+    qtndi.cpp \
+    ndireceiver.cpp \
+    ndireceiverworker.cpp \
+    ndisender.cpp \
+    ndiwrapper.cpp
+
+QMAKE_CXXFLAGS += /Zc:twoPhase-
+
+INCLUDEPATH += "../ndi/inc/"
+
+# Default rules for deployment.
+unix {
+    target.path = $$[QT_INSTALL_PLUGINS]/generic
+}
+!isEmpty(target.path): INSTALLS += target

--- a/lib/qtndi.cpp
+++ b/lib/qtndi.cpp
@@ -1,0 +1,5 @@
+#include "qtndi.h"
+
+QtNdi::QtNdi()
+{
+}

--- a/lib/qtndi.h
+++ b/lib/qtndi.h
@@ -1,0 +1,10 @@
+#ifndef QTNDI_H
+#define QTNDI_H
+
+class QtNdi
+{
+public:
+    QtNdi();
+};
+
+#endif // QTNDI_H


### PR DESCRIPTION
Restructures the project into a library and application setup.

This involves creating a QtNdi library project containing the core NDI functionality and an application project that utilizes this library.

This change improves modularity and facilitates code reuse.
