### PR TITLE
Capture system audio and send via NDI

### DIFF
--- a/app/MainWindow.h
+++ b/app/MainWindow.h
@@ -6,6 +6,9 @@
 #include <QScreenCapture>
 #include <QSystemTrayIcon>
 #include <QtMultimediaWidgets/QVideoWidget>
+#include <QAudioSource>
+#include <QMediaDevices>
+#include <QAudioFormat>
 
 #include "ndireceiver.h"
 #include "ndisender.h"
@@ -114,6 +117,9 @@ private:
     QScreenCapture *captureScreen = nullptr;
     QVideoSink *captureSink = nullptr;
     QMediaCaptureSession *mediaCaptureSession = nullptr;
+    QAudioSource *captureAudioSource = nullptr;
+    QIODevice *captureAudioIo = nullptr;
+    QAudioFormat captureAudioFormat;
     QMediaPlayer m_mediaPlayer;
     QVideoWidget m_videoWidget;
     QVideoSink* m_videoSink;
@@ -133,4 +139,5 @@ private slots:
     void onMediaCaptureVideoFrame(const QVideoFrame &frame);
     void onNdiSenderMetadataReceived(QString metadata);
     void onNdiSenderReceiverCountChanged(int receiverCount);
+    void onCaptureAudioReadyRead();
 };

--- a/lib/ndisender.h
+++ b/lib/ndisender.h
@@ -28,6 +28,8 @@ public:
     void stop();
 
     void sendVideoFrame(QVideoFrame const& frame);
+    void sendAudioFrame(const float* pData, int sampleCount,
+                        int sampleRate, int channelCount);
     void sendMetadata(QString const& metadata);
 
 signals:


### PR DESCRIPTION
## Summary
- Add audio capture using QAudioSource and route samples to the NDI sender.
- Extend `NdiSender` with `sendAudioFrame` for interleaved float audio.
- Start and stop audio capture alongside screen capture.

## Testing
- `qmake QtNdiProject.pro` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a27da8bfd88333a1eaa3c725a207dd