### PR TITLE
Prompt before exiting while capturing

### DIFF
--- a/app/MainWindow.cpp
+++ b/app/MainWindow.cpp
@@ -6,6 +6,7 @@
 #include <QContextMenuEvent>
 #include <QCoreApplication>
 #include <QDebug>
+#include <QMessageBox>
 #include <QMediaCaptureSession>
 #include <QMenu>
 #include <QVideoSink>
@@ -91,10 +92,23 @@ void MainWindow::closeEvent(QCloseEvent* event)
 {
     if (captureScreen->isActive())
     {
-        qDebug() << "TODO: Prompt if they really want to stop capturing and close";
-        hide();
-        event->ignore();
+        auto reply = QMessageBox::question(this,
+                                           tr("Capture Running"),
+                                           tr("A capture is currently active.\nDo you really want to exit?"),
+                                           QMessageBox::Yes | QMessageBox::No,
+                                           QMessageBox::No);
+        if (reply == QMessageBox::Yes)
+        {
+            captureStop();
+        }
+        else
+        {
+            hide();
+            event->ignore();
+            return;
+        }
     }
+    QMainWindow::closeEvent(event);
 }
 
 void MainWindow::showEvent(QShowEvent*)


### PR DESCRIPTION
## Summary
- warn users with a confirmation dialog when closing while a screen capture is active

## Testing
- `qmake -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2862674288333a06b05091036914a