### PR TITLE
Add loopback audio capture with format conversion

### DIFF
--- a/app/MainWindow.h
+++ b/app/MainWindow.h
@@ -6,6 +6,11 @@
 #include <QScreenCapture>
 #include <QSystemTrayIcon>
 #include <QtMultimediaWidgets/QVideoWidget>
+#include <QAudioSource>
+#include <QAudioFormat>
+#include <QAudioDevice>
+#include <QMediaDevices>
+#include <QIODevice>
 
 #include "ndireceiver.h"
 #include "ndisender.h"
@@ -129,8 +134,13 @@ private slots:
 private:
     QString m_selectedCaptureScreenName;
     NdiSender m_ndiSender;
+    QAudioSource* m_audioSource;
+    QIODevice* m_audioIODevice;
+    QAudioFormat m_audioFormat;
+    bool m_convertAudio;
 private slots:
     void onMediaCaptureVideoFrame(const QVideoFrame &frame);
+    void onAudioDataReady();
     void onNdiSenderMetadataReceived(QString metadata);
     void onNdiSenderReceiverCountChanged(int receiverCount);
 };

--- a/lib/ndisender.h
+++ b/lib/ndisender.h
@@ -28,6 +28,7 @@ public:
     void stop();
 
     void sendVideoFrame(QVideoFrame const& frame);
+    void sendAudioFrame(const float* data, int channelCount, int sampleRate, int sampleCount);
     void sendMetadata(QString const& metadata);
 
 signals:


### PR DESCRIPTION
## Summary
- Capture system audio by selecting a loopback `QAudioDevice` instead of default input
- Validate audio format, converting to 32-bit float when needed before sending via NDI
- Add `NdiSender::sendAudioFrame` and connect audio stream to NDI

## Testing
- `qmake QtNdiProject.pro` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2866501f083338b8418981a69e5ad