### PR TITLE
Allow disabling audio output

### DIFF
--- a/app/MainWindow.h
+++ b/app/MainWindow.h
@@ -6,6 +6,7 @@
 #include <QScreenCapture>
 #include <QSystemTrayIcon>
 #include <QtMultimediaWidgets/QVideoWidget>
+#include <QAudioDevice>
 
 #include "ndireceiver.h"
 #include "ndisender.h"
@@ -106,6 +107,7 @@ private slots:
     void onActionFullScreenTriggered();
     void onActionRestoreWindowTriggered();
     void onActionExitTriggered();
+    void onActionAudioOutputDeviceTriggered();
 
 private:
     void setFullScreen(bool fullScreen);
@@ -129,6 +131,7 @@ private slots:
 private:
     QString m_selectedCaptureScreenName;
     NdiSender m_ndiSender;
+    QAudioDevice m_selectedAudioOutputDevice;
 private slots:
     void onMediaCaptureVideoFrame(const QVideoFrame &frame);
     void onNdiSenderMetadataReceived(QString metadata);

--- a/lib/ndireceiver.cpp
+++ b/lib/ndireceiver.cpp
@@ -1,6 +1,7 @@
 #include "ndireceiver.h"
 
 #include <QDebug>
+#include <QAudioDevice>
 
 NdiReceiver::NdiReceiver(QObject *parent)
     : QObject(parent)
@@ -29,6 +30,8 @@ void NdiReceiver::init()
     connect(&m_workerNdiReceiver, &NdiReceiverWorker::onSourceConnected, this, &NdiReceiver::onSourceConnected);
     connect(&m_workerNdiReceiver, &NdiReceiverWorker::onVideoFrameReceived, this, &NdiReceiver::onVideoFrameReceived);
     connect(&m_workerNdiReceiver, &NdiReceiverWorker::onSourceDisconnected, this, &NdiReceiver::onSourceDisconnected);
+    qRegisterMetaType<QAudioDevice>("QAudioDevice");
+    connect(this, &NdiReceiver::audioOutputDeviceChanged, &m_workerNdiReceiver, &NdiReceiverWorker::setAudioOutputDevice);
 
     qDebug() << "-init()";
 }
@@ -72,4 +75,9 @@ void NdiReceiver::sendMetadata(const QString& metadata)
 void NdiReceiver::muteAudio(bool bMute)
 {
     m_workerNdiReceiver.muteAudio(bMute);
+}
+
+void NdiReceiver::setAudioOutputDevice(const QAudioDevice& device)
+{
+    emit audioOutputDeviceChanged(device);
 }

--- a/lib/ndireceiver.h
+++ b/lib/ndireceiver.h
@@ -4,6 +4,7 @@
 #include <QObject>
 #include <QSharedDataPointer>
 #include <QThread>
+#include <QAudioDevice>
 
 #include "ndireceiverworker.h"
 
@@ -22,12 +23,14 @@ public:
     void selectSource(const QString& sourceName);
     void sendMetadata(const QString& metadata);
     void muteAudio(bool bMute);
+    void setAudioOutputDevice(const QAudioDevice& device);
 
 signals:
     void onSourceConnected(const QString& sourceName);
     void onMetadataReceived(const QString& metadata);
     void onVideoFrameReceived(const QVideoFrame& videoFrame);
     void onSourceDisconnected(const QString& sourceName);
+    void audioOutputDeviceChanged(const QAudioDevice& device);
 
 private:
     NdiReceiverWorker m_workerNdiReceiver;

--- a/lib/ndireceiverworker.h
+++ b/lib/ndireceiverworker.h
@@ -2,6 +2,7 @@
 #define NDIRECEIVERWORKER_H
 
 #include <QObject>
+#include <QAudioDevice>
 #include <QAudioFormat>
 #include <QAudioSink>
 #include <QList>
@@ -39,6 +40,7 @@ signals:
 public slots:
     void run();
     void stop();
+    void setAudioOutputDevice(const QAudioDevice& audioDevice);
 
 private:
     bool               m_bReconnect;
@@ -55,6 +57,9 @@ private:
     QString            m_cIDX;
 
     float              m_fAudioLevels[MAX_AUDIO_LEVELS];
+
+    QAudioDevice       m_audioOutputDevice;
+    bool               m_bAudioOutputDeviceChanged;
 
     void init();
     void processVideo(const NDIlib_video_frame_v2_t& pVideoFrameNdi);


### PR DESCRIPTION
## Summary
- add "None" entry to audio output device menu and wire it to the receiver
- handle empty audio device selection so worker skips creating QAudioSink

## Testing
- `qmake QtNdiProject.pro` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y qtbase5-dev` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68a390826ed883338e00d6e9eec82bdc